### PR TITLE
Replace img tag with Next.js Image

### DIFF
--- a/components/contact-form.tsx
+++ b/components/contact-form.tsx
@@ -1,7 +1,7 @@
-/* eslint-disable @next/next/no-img-element */
 "use client";
 
 import * as React from "react";
+import Image from "next/image";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { Button } from "@/components/ui/button";
@@ -267,9 +267,11 @@ export function ContactForm() {
                             className="px-3 py-2"
                           >
                             <div className="flex items-center gap-3">
-                              <img
+                              <Image
                                 src={country.img || "/placeholder.svg"}
                                 alt={`Bandeira ${country.pais}`}
+                                width={20}
+                                height={12}
                                 className="w-5 h-3 object-cover rounded-sm"
                               />
                               <span className="font-medium">


### PR DESCRIPTION
## Summary
- replace `<img>` usage with `next/image` in contact form
- remove unused ESLint disable comment

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684849926604832ea417c15f4fcc3630