### PR TITLE
Convert next.config.ts to ESM

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,10 +1,12 @@
-/** @type {import('next').NextConfig} */
-const withMDX = require('@next/mdx')({
+import withMDX from '@next/mdx'
+
+const withMDXConfig = withMDX({
   extension: /\.mdx?$/,
 })
 
-const nextConfig = withMDX({
+/** @type {import('next').NextConfig} */
+const nextConfig = withMDXConfig({
   pageExtensions: ['ts', 'tsx', 'mdx'],
 })
 
-module.exports = nextConfig
+export default nextConfig


### PR DESCRIPTION
## Summary
- use ES module syntax in `next.config.ts`

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json`
- `npm run build` *(fails: Missing env.NEXT_PUBLIC_SUPABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68555e359ebc832e8a988240a159e835