### PR TITLE
Refactor Supabase init

### DIFF
--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,9 +1,10 @@
 import { NextResponse } from "next/server";
 import { contactFormSchema } from "@/lib/types";
-import { supabase } from "@/lib/supabase";
+import { getSupabaseClient } from "@/lib/supabase";
 
 export async function POST(request: Request) {
   try {
+    const supabase = getSupabaseClient()
     const body = await request.json();
 
     // Validate the request body

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,11 +1,22 @@
-import { createClient } from "@supabase/supabase-js"
+import { createClient, type SupabaseClient } from "@supabase/supabase-js"
 
-if (!process.env.NEXT_PUBLIC_SUPABASE_URL) {
-  throw new Error("Missing env.NEXT_PUBLIC_SUPABASE_URL")
-}
-if (!process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) {
-  throw new Error("Missing env.NEXT_PUBLIC_SUPABASE_ANON_KEY")
-}
+let supabase: SupabaseClient | null = null
 
-export const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY)
+export function getSupabaseClient(): SupabaseClient {
+  if (!supabase) {
+    const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+    if (!url) {
+      throw new Error("Missing env.NEXT_PUBLIC_SUPABASE_URL")
+    }
+
+    const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+    if (!key) {
+      throw new Error("Missing env.NEXT_PUBLIC_SUPABASE_ANON_KEY")
+    }
+
+    supabase = createClient(url, key)
+  }
+
+  return supabase
+}
 


### PR DESCRIPTION
## Summary
- lazily initialize the Supabase client
- expose a `getSupabaseClient` helper
- use the helper in the contact API route

## Testing
- `npx next lint`

------
https://chatgpt.com/codex/tasks/task_e_685563e3d7d4832eb1210d4edee2c5ae