### PR TITLE
Add Google verification meta tag

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -25,6 +25,12 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="pt-BR" className={`${lato.className} ${geist.className}`}>
+      <head>
+        <meta
+          name="google-site-verification"
+          content="QMSOkaqxsXZzibvg49qJjlwTNIozWkXyT4e-PbtOlTU"
+        />
+      </head>
       <body>
         {children}
         <SpeedInsights />


### PR DESCRIPTION
## Summary
- add google-site-verification meta tag in root layout

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687923320430832e817b60aa7bc07e5e