### PR TITLE
Enhance SEO metadata

### DIFF
--- a/app/blog/artigos/casos-sucesso-ia-atendimento-cliente/page.tsx
+++ b/app/blog/artigos/casos-sucesso-ia-atendimento-cliente/page.tsx
@@ -3,6 +3,20 @@ import { MainNav } from "@/components/main-nav"
 import { ArrowLeft } from "lucide-react"
 import { Newsletter } from "@/app/components/Newsletter/newsletter"
 import Share from "@/app/components/Share"
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Casos de Sucesso: IA Revolucionando o Atendimento ao Cliente",
+  description:
+    "Conheça como grandes empresas estão usando inteligência artificial para revolucionar o atendimento e aumentar a satisfação dos clientes.",
+  openGraph: {
+    title: "Casos de Sucesso: IA Revolucionando o Atendimento ao Cliente",
+    description:
+      "Conheça como grandes empresas estão usando inteligência artificial para revolucionar o atendimento e aumentar a satisfação dos clientes.",
+    url: "/blog/artigos/casos-sucesso-ia-atendimento-cliente",
+    images: ["/images/sucesso.jpg"],
+  },
+}
 
 export default function CasosSucessoIAPage() {
   return (

--- a/app/blog/artigos/futuro-crm-inteligencia-artificial-personalizacao/page.tsx
+++ b/app/blog/artigos/futuro-crm-inteligencia-artificial-personalizacao/page.tsx
@@ -4,6 +4,20 @@ import { Button } from "@/components/ui/button"
 import { ArrowLeft, Twitter, Facebook, Linkedin, Share2 } from "lucide-react"
 import { Newsletter } from "@/app/components/Newsletter/newsletter"
 import Cta from "@/app/Cta"
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "O Futuro do CRM: Inteligência Artificial e Personalização",
+  description:
+    "Descubra como a IA está transformando os sistemas de CRM e criando experiências altamente personalizadas.",
+  openGraph: {
+    title: "O Futuro do CRM: Inteligência Artificial e Personalização",
+    description:
+      "Descubra como a IA está transformando os sistemas de CRM e criando experiências altamente personalizadas.",
+    url: "/blog/artigos/futuro-crm-inteligencia-artificial-personalizacao",
+    images: ["/images/sucesso.jpg"],
+  },
+}
 
 export default function FuturoCRMPage() {
   return (

--- a/app/blog/artigos/ia-agentiva-transformando-negocios/page.tsx
+++ b/app/blog/artigos/ia-agentiva-transformando-negocios/page.tsx
@@ -3,6 +3,21 @@ import { MainNav } from "@/components/main-nav"
 import { Button } from "@/components/ui/button"
 import { ArrowLeft, Twitter, Facebook, Linkedin, Share2 } from "lucide-react"
 import { Newsletter } from "@/app/components/Newsletter/newsletter"
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "IA Agentiva: Como a Nova Geração da Inteligência Artificial Está Transformando os Negócios",
+  description:
+    "Conheça como a IA agentiva está revolucionando empresas com sistemas que tomam decisões e executam ações de forma autônoma.",
+  openGraph: {
+    title:
+      "IA Agentiva: Como a Nova Geração da Inteligência Artificial Está Transformando os Negócios",
+    description:
+      "Conheça como a IA agentiva está revolucionando empresas com sistemas que tomam decisões e executam ações de forma autônoma.",
+    url: "/blog/artigos/ia-agentiva-transformando-negocios",
+    images: ["/images/ia-agentiva-negocios.png"],
+  },
+}
 
 export default function IAAgentivaPage() {
   return (

--- a/app/blog/artigos/implementar-automacao-marketing-resultados/page.tsx
+++ b/app/blog/artigos/implementar-automacao-marketing-resultados/page.tsx
@@ -4,6 +4,20 @@ import { Button } from "@/components/ui/button"
 import { ArrowLeft, Twitter, Facebook, Linkedin, Share2 } from "lucide-react"
 import { Newsletter } from "@/app/components/Newsletter/newsletter"
 import Cta from "@/app/Cta"
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Como Implementar Automação de Marketing com Resultados Reais",
+  description:
+    "Guia prático para implementar automação de marketing que gera leads qualificados e aumenta a conversão.",
+  openGraph: {
+    title: "Como Implementar Automação de Marketing com Resultados Reais",
+    description:
+      "Guia prático para implementar automação de marketing que gera leads qualificados e aumenta a conversão.",
+    url: "/blog/artigos/implementar-automacao-marketing-resultados",
+    images: ["/images/resultados.png"],
+  },
+}
 
 export default function AutomacaoMarketingPage() {
   return (

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -2,6 +2,19 @@ import { MainNav } from "@/components/main-nav"
 import { getAllArticles } from "@/lib/get-articles"
 import BlogClient from "./client"
 import { Newsletter } from "../components/Newsletter/newsletter"
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Blog",
+  description:
+    "Artigos, dicas e estratégias sobre automação de vendas, prospecção e atendimento inteligente",
+  openGraph: {
+    title: "Blog",
+    description:
+      "Artigos, dicas e estratégias sobre automação de vendas, prospecção e atendimento inteligente",
+    url: "/blog",
+  },
+}
 
 // Make this a Server Component to fetch articles at build time
 export default async function BlogPage() {

--- a/app/contato/page.tsx
+++ b/app/contato/page.tsx
@@ -7,6 +7,18 @@ import Particles from "react-tsparticles"
 import { MainNav } from "@/components/main-nav"
 import { Footer } from "@/components/footer"
 import { ContactPageContent } from "@/components/contact-page-content"
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Contato",
+  description: "Fale conosco para saber mais sobre nossas soluções de automação e IA.",
+  openGraph: {
+    title: "Contato",
+    description:
+      "Fale conosco para saber mais sobre nossas soluções de automação e IA.",
+    url: "/contato",
+  },
+}
 
 export default function ContactPage() {
   const [mounted, setMounted] = useState(false)

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -14,8 +14,27 @@ const geist = Geist({
 });
 
 export const metadata: Metadata = {
-  title: "AIG",
+  metadataBase: new URL(
+    process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000"
+  ),
+  title: {
+    default: "AIG",
+    template: "%s | AIG",
+  },
   description: "Automação e Inteligência Artificial aplicados na sua empresa",
+  openGraph: {
+    title: "AIG",
+    description:
+      "Automação e Inteligência Artificial aplicados na sua empresa",
+    url: "/",
+    siteName: "AIG",
+    locale: "pt_BR",
+    type: "website",
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
 };
 
 export default function RootLayout({

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,6 +12,20 @@ import { FaqSection } from "@/components/faq-section"
 import { ContactSection } from "@/components/contact-section"
 import { Footer } from "@/components/footer"
 import { ChevronDown } from "lucide-react"
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Automação Inteligente para Escalar suas Vendas",
+  description:
+    "Prospecção automatizada, atendimento inteligente e gestão eficiente para transformar leads em clientes.",
+  openGraph: {
+    title: "Automação Inteligente para Escalar suas Vendas",
+    description:
+      "Prospecção automatizada, atendimento inteligente e gestão eficiente para transformar leads em clientes.",
+    url: "/",
+    images: ["/images/sucesso.jpg"],
+  },
+}
 
 export default function Hero() {
   const [mounted, setMounted] = useState(false)

--- a/app/sobre-nos/page.tsx
+++ b/app/sobre-nos/page.tsx
@@ -7,6 +7,17 @@ import Particles from "react-tsparticles"
 import { MainNav } from "@/components/main-nav"
 import { Footer } from "@/components/footer"
 import { AboutSection } from "@/components/about-section"
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Sobre Nós",
+  description: "Conheça mais sobre a AIG e nossa missão de automatizar vendas com inteligência.",
+  openGraph: {
+    title: "Sobre Nós",
+    description: "Conheça mais sobre a AIG e nossa missão de automatizar vendas com inteligência.",
+    url: "/sobre-nos",
+  },
+}
 
 export default function AboutPage() {
   const [mounted, setMounted] = useState(false)

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: /sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>/</loc></url>
+  <url><loc>/blog</loc></url>
+  <url><loc>/contato</loc></url>
+  <url><loc>/sobre-nos</loc></url>
+  <url><loc>/blog/artigos/casos-sucesso-ia-atendimento-cliente</loc></url>
+  <url><loc>/blog/artigos/futuro-crm-inteligencia-artificial-personalizacao</loc></url>
+  <url><loc>/blog/artigos/ia-agentiva-transformando-negocios</loc></url>
+  <url><loc>/blog/artigos/implementar-automacao-marketing-resultados</loc></url>
+</urlset>


### PR DESCRIPTION
## Summary
- add default SEO metadata in layout
- add page-specific metadata for marketing pages and blog posts
- include robots.txt and sitemap.xml

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68792294baac832eb7188db87552a1fe